### PR TITLE
Upgrade to AWS CLI v2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2023-10-08
+
+### Added
+
+- Dependabot updates.
+- Documentation updates.
+
 ## [1.0.2] - 2023-07-29
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,9 @@ COPY requirements.txt /ripper
 COPY bb-ripper/ /ripper/
 COPY setup.sh /ripper
 
-RUN chmod +x setup.sh
-RUN /ripper/setup.sh
-RUN rm /ripper/setup.sh
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git
-RUN  pip install -r requirements.txt
+RUN chmod +x setup.sh && ./setup.sh && rm setup.sh
+RUN pip install -r requirements.txt
 
 VOLUME /data
 

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,18 @@ set -ex
 
 # Install AWS CLI 
 if [ "$AWSCLI" == "TRUE" ] ; then 
-    pip3 install awscli ; 
+    # Required for AWS CLI download and unzip. Remove after installation.
+    apt-get install -y curl unzip ;
+    
+    # Download and install AWS CLI. Clean up after installation.
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" ;
+    unzip awscliv2.zip ;
+    ./aws/install ;
+    rm -rf aws ;
+    rm -rf awscliv2.zip ;
+
+    # Clean up after installation.  
+    apt-get -y --purge remove curl unzip ;
 else 
     echo Argument not provided ; 
 fi


### PR DESCRIPTION
Removes the AWS CLI installed with pip which is v1.
The setup is changed to download the binary and install from AWS.