### PR TITLE
Release 1.2.7: Add Bitbucket API token support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,13 +4,15 @@ on:
   push:
     branches:
       - '*'
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
 
-  build-and-test:
+  build-and-test-app-password:
+    name: Test with App Password (Legacy)
     runs-on: ubuntu-latest
     
     steps:
@@ -23,10 +25,33 @@ jobs:
           python-version: '3.12'
       - run: pip install -r requirements.txt
       - run: pip install pylint && pylint ./bb-ripper/
-      - run: python3 ./bb-ripper/.
+      - name: Test with App Password
+        run: python3 ./bb-ripper/.
         env:
           BB_USER : ${{ secrets.BB_USER }}
           BB_WORKSPACE: ${{ secrets.BB_WORKSPACE }}
           BB_PASSWORD: ${{ secrets.BB_PASSWORD }}
+          BB_RIPPER_EXPORT_DIRECTORY: ${{ secrets.BB_RIPPER_EXPORT_DIRECTORY }}
+
+  build-and-test-api-token:
+    name: Test with API Token (Recommended)
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@main
+    
+      - name: Setup Python
+        uses: actions/setup-python@main
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+      - run: pip install pylint && pylint ./bb-ripper/
+      - name: Test with API Token
+        run: python3 ./bb-ripper/.
+        env:
+          BB_EMAIL: ${{ secrets.BB_EMAIL }}
+          BB_API_TOKEN: ${{ secrets.BB_API_TOKEN }}
+          BB_WORKSPACE: ${{ secrets.BB_WORKSPACE }}
           BB_RIPPER_EXPORT_DIRECTORY: ${{ secrets.BB_RIPPER_EXPORT_DIRECTORY }}
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.7] - 2026-03-05
+
+### Added
+
+- Support for Bitbucket API tokens alongside app passwords
+- New `BB_EMAIL` and `BB_API_TOKEN` environment variables for API token authentication
+- Automatic authentication mode detection based on environment variables
+- New `auth_helper` module for centralized authentication handling
+
+### Changed
+
+- Updated `bbhelper.py` to use new authentication helper for REST API calls
+- Updated `ripper_utils.py` to use new authentication helper for git operations
+- Updated `README.md` with comprehensive authentication documentation
+- Updated `docenv.example` to show both authentication methods
+
+### Note
+
+- App passwords are deprecated by Atlassian and will stop working on June 9, 2026
+- API token support is now the recommended authentication method
+- Backward compatibility maintained for existing app password users
+
 ## [1.2.6] - 2026-03-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -4,11 +4,42 @@ This project downloads all Bitbucket repositories and every branch for each repo
 
 ## Bitbucket Authentication
 
-This application works with [Bitbucket App Passwords](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/)
+This application supports two authentication methods:
+
+### API Tokens (Recommended)
+
+**Required after June 9, 2026** when app passwords are deprecated.
+
+API tokens provide:
+- Expiration control
+- Centralized management for admins
+- Modern security scopes
+
+[Create an API token](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/)
+
+### App Passwords (Legacy - Deprecated)
+
+⚠️ **App passwords will stop working on June 9, 2026**
+
+Existing app passwords will continue to work until that date, but no new app passwords can be created as of September 9, 2025.
+
+[More about app password deprecation](https://www.atlassian.com/blog/bitbucket/bitbucket-cloud-transitions-to-api-tokens-enhancing-security-with-app-password-deprecation)
 
 ## Environment Settings
 
 The application requires the following environment variables to run.
+
+### For API Token Authentication (Recommended)
+
+`BB_EMAIL` Your Atlassian account email.
+
+`BB_API_TOKEN` Your Bitbucket API token.
+
+`BB_WORKSPACE` The name of the Bitbucket workspace.
+
+`BB_RIPPER_EXPORT_DIRECTORY` The path of the output.
+
+### For App Password Authentication (Legacy)
 
 `BB_USER` The username component of the Bitbucket App Password.
 
@@ -18,7 +49,9 @@ The application requires the following environment variables to run.
 
 `BB_RIPPER_EXPORT_DIRECTORY` The path of the output.
 
-With the optional environment variable `BB_TEST_COUNTER` you can pull down only a specified number of repositories. This is useful for testing purposes. All values that are non integer and lower that 1 will be ignored.
+### Optional Settings
+
+`BB_TEST_COUNTER` Limit the number of repositories to process (useful for testing). All values that are non-integer or less than 1 will be ignored.
 
 ## Running the ripper
 

--- a/bb-ripper/auth_helper.py
+++ b/bb-ripper/auth_helper.py
@@ -1,0 +1,105 @@
+"""
+Module that provides authentication helper functions for Bitbucket.
+
+Supports both app passwords (legacy) and API tokens.
+Detection is based on environment variables:
+- If BB_API_TOKEN is set: use API token mode
+- Otherwise: use app password mode (requires BB_USER + BB_PASSWORD)
+"""
+import os
+import re
+
+
+def get_auth_mode():
+    """
+    Determine which authentication mode to use based on environment variables.
+    
+    Returns:
+        str: 'api_token' or 'app_password'
+    """
+    if 'BB_API_TOKEN' in os.environ:
+        return 'api_token'
+    return 'app_password'
+
+
+def get_api_auth():
+    """
+    Get authentication credentials for REST API calls.
+
+    Returns:
+        tuple: (username, password/token) for use with requests.auth
+
+    For API token mode: returns (email, token)
+    For app password mode: returns (username, password)
+    """
+    mode = get_auth_mode()
+
+    if mode == 'api_token':
+        # API tokens require email for REST API calls
+        email = os.environ.get('BB_EMAIL')
+        token = os.environ.get('BB_API_TOKEN')
+
+        if not email:
+            raise ValueError("BB_EMAIL is required when using BB_API_TOKEN")
+        if not token:
+            raise ValueError("BB_API_TOKEN is set but empty")
+
+        return (email, token)
+
+    # App password mode
+    user = os.environ.get('BB_USER')
+    password = os.environ.get('BB_PASSWORD')
+
+    if not user:
+        raise ValueError("BB_USER is required when not using BB_API_TOKEN")
+    if not password:
+        raise ValueError(
+            "BB_PASSWORD is required when not using BB_API_TOKEN")
+
+    return (user, password)
+
+
+def get_git_https_url(base_url):
+    """
+    Transform a Bitbucket HTTPS URL to include authentication credentials.
+
+    Args:
+        base_url (str): The base HTTPS URL from Bitbucket
+                        (e.g., https://bitbucket.org/workspace/repo.git
+                        or https://username@bitbucket.org/workspace/repo.git)
+
+    Returns:
+        str: The URL with embedded credentials
+
+    For API token mode: https://x-bitbucket-api-token-auth:{token}@...
+    For app password mode: https://{username}:{password}@bitbucket.org/...
+    """
+    mode = get_auth_mode()
+
+    # First, remove any existing username from the URL to normalize it
+    # Bitbucket URLs may come in format: https://username@bitbucket.org/...
+    # We need to strip the username part first
+    clean_url = re.sub(r'https://[^@]+@', 'https://', base_url)
+
+    if mode == 'api_token':
+        # API tokens use static username for git operations
+        token = os.environ.get('BB_API_TOKEN')
+
+        if not token:
+            raise ValueError("BB_API_TOKEN is set but empty")
+
+        # Replace https:// with https://x-bitbucket-api-token-auth:{token}@
+        return clean_url.replace(
+            'https://', f'https://x-bitbucket-api-token-auth:{token}@')
+
+    # App password mode
+    user = os.environ.get('BB_USER')
+    password = os.environ.get('BB_PASSWORD')
+
+    if not user:
+        raise ValueError("BB_USER is required when not using BB_API_TOKEN")
+    if not password:
+        raise ValueError("BB_PASSWORD is required when not using BB_API_TOKEN")
+
+    # Replace https:// with https://{user}:{password}@
+    return clean_url.replace('https://', f'https://{user}:{password}@')

--- a/bb-ripper/bbhelper.py
+++ b/bb-ripper/bbhelper.py
@@ -3,6 +3,7 @@ import os
 import json
 import logging
 import requests
+from auth_helper import get_api_auth
 
 BB_API_ENDPOINT = 'https://api.bitbucket.org/2.0'
 
@@ -31,7 +32,7 @@ class BBProject:
         logging.info("Get projects request endpoint %s", request_endpoint)
 
         session = requests.session()
-        session.auth = (os.environ['BB_USER'], os.environ['BB_PASSWORD'])
+        session.auth = get_api_auth()
 
         projects_request = session.get(request_endpoint)
         projects_json = json.loads(projects_request.text)
@@ -72,7 +73,7 @@ class BBRepo:
                      request_endpoint)
 
         session = requests.session()
-        session.auth = (os.environ['BB_USER'], os.environ['BB_PASSWORD'])
+        session.auth = get_api_auth()
 
         repos = []
 

--- a/bb-ripper/ripper_utils.py
+++ b/bb-ripper/ripper_utils.py
@@ -6,6 +6,7 @@ import subprocess
 from datetime import datetime
 from shutil import which
 import shutil
+from auth_helper import get_git_https_url
 
 output_dir = ""
 output_base = ""
@@ -58,7 +59,7 @@ def clone_repo(repo, output_dir):
         os.makedirs(clone_dir)
     os.chdir(clone_dir)
     # make sure to suppress output when using https
-    os.system(f"git clone {get_https_url(repo.https)} . >/dev/null 2>&1")
+    os.system(f"git clone {get_git_https_url(repo.https)} . >/dev/null 2>&1")
 
     branches = subprocess.run(["git", "branch", "-r"],
                               stdout=subprocess.PIPE,
@@ -83,11 +84,3 @@ def zip_output_dir():
     print(f"Dir to zip: {directory}")
     os.chdir(output_base)
     os.system(f"tar -cvzf {directory}.tar.gz {directory}/")
-
-def get_https_url(url):
-    """
-    Function that returns a https uld that contains the username and password.
-    """
-    search_text = f"https://{os.environ['BB_USER']}"
-    replace_text = f"https://{ os.environ['BB_USER']}:{os.environ['BB_PASSWORD']}"
-    return url.replace(search_text, replace_text)

--- a/docenv.example
+++ b/docenv.example
@@ -1,4 +1,27 @@
-BB_USER=
-BB_PASSWORD=
-BB_WORKSPACE=
-BB_RIPPER_EXPORT_DIRECTORY=
+# Bitbucket Authentication Configuration
+# Choose ONE of the following authentication methods:
+
+# ============================================
+# Option 1: App Password (LEGACY - deprecated)
+# ============================================
+# App passwords work until June 9, 2026
+# After that date, you MUST use API tokens
+#
+# BB_USER=your_bitbucket_username
+# BB_PASSWORD=your_app_password
+# BB_WORKSPACE=your_workspace_name
+# BB_RIPPER_EXPORT_DIRECTORY=/path/to/output
+
+# ============================================
+# Option 2: API Token (RECOMMENDED)
+# ============================================
+# Required after June 9, 2026
+# More secure with expiration control and centralized management
+#
+BB_EMAIL=your.email@example.com
+BB_API_TOKEN=ATBBxxx...
+BB_WORKSPACE=your_workspace_name
+BB_RIPPER_EXPORT_DIRECTORY=/path/to/output
+
+# Optional: Limit number of repos for testing
+# BB_TEST_COUNTER=5


### PR DESCRIPTION
## Release 1.2.7

Adds support for Bitbucket API tokens while maintaining backward compatibility with app passwords.

### Summary

App passwords are being deprecated by Atlassian and will stop working on **June 9, 2026**. This release adds support for API tokens, which are now the recommended authentication method.

### Changes

**Added:**
- Support for Bitbucket API tokens alongside app passwords
- New `BB_EMAIL` and `BB_API_TOKEN` environment variables
- Automatic authentication mode detection
- New `auth_helper` module for centralized authentication

**Updated:**
- `bbhelper.py` - Use auth helper for REST API calls
- `ripper_utils.py` - Use auth helper for git operations
- `README.md` - Comprehensive auth documentation
- `docenv.example` - Show both auth methods
- `CHANGELOG.md` - Release notes

### Authentication Methods

**API Token (Recommended):**
```bash
BB_EMAIL=your.email@example.com
BB_API_TOKEN=ATBBxxx...
BB_WORKSPACE=workspace
BB_RIPPER_EXPORT_DIRECTORY=/path/to/output
```

**App Password (Legacy - works until June 9, 2026):**
```bash
BB_USER=username
BB_PASSWORD=app_password
BB_WORKSPACE=workspace
BB_RIPPER_EXPORT_DIRECTORY=/path/to/output
```

### Testing

- [x] Tested with API token credentials - ✅ Working
- [x] Tested with app password credentials - ✅ Working  
- [x] Verified REST API calls work with both methods
- [x] Verified git clone operations work with both methods
- [x] All tests pass locally

### Migration Guide

Users can migrate by:
1. [Creating an API token](https://support.atlassian.com/bitbucket-cloud/docs/create-an-api-token/)
2. Switching to `BB_EMAIL` + `BB_API_TOKEN` environment variables
3. Removing `BB_USER` + `BB_PASSWORD`

No code changes required - detection is automatic based on which environment variables are set.

Closes #211
